### PR TITLE
Feature/chap 957 page template edit

### DIFF
--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -123,7 +123,9 @@ export const parameters = {
         '👋 Get started', ['Welcome', 'Colors', 'Type Scale', 'Layout', 'Changelog'],
         '💧 Atoms', 
         '🌱 Molecules', 
-        '🌳 Organisms'
+        '🌳 Organisms',
+        '📄 Templates',
+        '📙 Pages'
       ],
     },
   }

--- a/src/components/_helpers/Wrapper.tsx
+++ b/src/components/_helpers/Wrapper.tsx
@@ -14,7 +14,7 @@ export interface WrapperProps {
 }
 
 // T Y P E S
-export type WrapperBgColor = 'light' | 'dark' | 'black' | 'transparent'
+export type WrapperBgColor = 'light' | 'dark' | 'black' | 'transparent' | 'black-darker'
 export type WrapperDirection = 'row' | 'column'
 export type WrapperAlignment = 'center' | 'flex-start' | 'flex-end' | 'stretch' | 'space-between' | 'space-around'
 export type WrapperFlexWrap = 'nowrap' | 'wrap'
@@ -63,6 +63,10 @@ const StyledWrapper = styled.div`
 
   &.black {
     background-color: var(--color-black);
+  }
+
+  &.black-darker {
+    background-color: var(--color-black-darker);
   }
 
   &.transparent {

--- a/src/components/atoms/Button/Button.tsx
+++ b/src/components/atoms/Button/Button.tsx
@@ -8,6 +8,7 @@ import { Icon, IconName } from '../Icon/Icon'
 export interface ButtonProps {
   className?: string
   icon?: IconName
+  iconOnly?: boolean
   onClick?: () => void
   size?: ButtonSize
   style?: React.CSSProperties
@@ -26,6 +27,7 @@ export const Button: React.FC<ButtonProps> = ({
   children,
   className,
   icon,
+  iconOnly = false,
   onClick,
   size = 'md',
   style,
@@ -35,12 +37,12 @@ export const Button: React.FC<ButtonProps> = ({
   return (
     <StyledButton
       style={style}
-      className={`btn ${type} ${size} ${width} ${className}`}
+      className={`btn ${type} ${size} ${width} ${iconOnly && 'icon-only'} ${className}`}
       type={type === 'submit' ? 'submit' : 'button'}
       onClick={(): void => { return (onClick && onClick()) }}
       icon={icon}
     >
-      {icon && <Icon icon={icon} />}
+      {icon && <Icon icon={icon} className={`${iconOnly && 'icon-only'}`} />}
       {children}
     </StyledButton>
   )
@@ -62,6 +64,13 @@ const StyledButton = styled.button`
   border-radius: var(--radius);
   outline: none;
   transition: var(--transition);
+
+  &.icon-only {
+    padding: var(--space-lg);
+    i {
+      margin-right: 0;
+    }
+  }
 
   i {
     margin-right: var(--space-md);
@@ -116,7 +125,7 @@ const StyledButton = styled.button`
     color: var(--color-black);
   }
 
-  &:hover {
+  &:hover, &:focus {
     background-color: var(--color-primary-light);
     color: var(--color-white-fix);
     box-shadow: 0 0 6px var(--color-light-10);

--- a/src/components/atoms/Button/ButtonGroup.tsx
+++ b/src/components/atoms/Button/ButtonGroup.tsx
@@ -1,0 +1,40 @@
+import React from 'react'
+import styled from 'styled-components'
+
+export interface ButtonGroupProps {
+  className?: string
+  style?: React.CSSProperties
+}
+
+export const ButtonGroup: React.FC<ButtonGroupProps> = ({
+  className,
+  children,
+  style
+}) => {
+  return (
+    <StyledButtonGroup
+      className={`button-group ${className}`}
+      style={style}
+    >
+      {children}
+    </StyledButtonGroup>
+  )
+}
+
+const StyledButtonGroup = styled.div`
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  
+  .btn {
+    margin: 0 15px;
+    
+    &:first-child {
+      margin-left: 0;
+    }
+    
+    &:last-child {
+      margin-right: 0;
+    }
+  }
+`

--- a/src/components/atoms/CaretLink/CaretLink.tsx
+++ b/src/components/atoms/CaretLink/CaretLink.tsx
@@ -45,6 +45,7 @@ const StyledCaretLink = styled.div`
     text-decoration: none;
     color: var(--color-white);
     transition: var(--transition);
+    outline: none;
 
     i {
       position: absolute;
@@ -62,7 +63,7 @@ const StyledCaretLink = styled.div`
       transition: var(--transition);
     }
 
-    &:hover {
+    &:hover, &:focus {
       padding-left: 0;
 
       i {

--- a/src/components/atoms/Input/helpers/InputIcon.tsx
+++ b/src/components/atoms/Input/helpers/InputIcon.tsx
@@ -49,7 +49,7 @@ const StyledInputIcon = styled.div<StyledInputIconProps>`
   min-width: 44px;
   min-height: 100%;
   color: var(--color-white);
-  border-radius: 10px 0 0 10px;
+  border-radius: 9px 0 0 9px;
   transition: var(--transition);
   
   svg {

--- a/src/components/atoms/Input/helpers/TextInput.tsx
+++ b/src/components/atoms/Input/helpers/TextInput.tsx
@@ -177,11 +177,12 @@ const StyledInput = styled.div<StyledInputProps>`
   position: relative;
   margin-bottom: var(--space-xl);
   border: var(--border);
-  background-color: var(--color-dark);
+  background-color: var(--color-black);
   width: 100%;
   min-width: 240px;
   font-size: 1em;
   border-radius: var(--radius);
+  transition: all 200ms ease-in-out;
 
   &.error {
     margin-bottom: var(--space-lgr);
@@ -197,6 +198,7 @@ const StyledInput = styled.div<StyledInputProps>`
     z-index: 10;
     border: none;
     background: transparent;
+    cursor: pointer;
     width: 44px;
     height: 44px;
     outline: none;
@@ -235,50 +237,51 @@ const StyledInput = styled.div<StyledInputProps>`
   
   .input-label {
     position: absolute;
-    top: 0.25rem;
+    top: .1875rem;
     left: 12px;
     z-index: 1;
     opacity: 0.5;
     color: var(--color-white);
     font-size: 10px;
     font-weight: 800;
+    transform: scale(1);
+    transform-origin: left;
+    transition: all 200ms ease-in-out;
   }
   
   input {
     position: relative;
-    border: 0;
+    border: none;
     background: transparent;
     padding: var(--space-fixed-md) var(--space-fixed-md) 0 var(--space-fixed-md);
     width: 100%;
     height: 2.75rem;
+    border-radius: var(--border-radius);
     color: var(--color-white);
     outline: none;
-    transition: var(--transition);
-  }
-  
-  label {
-    color: var(--color-white);
+    transition: top 200ms ease-in-out;
   }
 
   &.empty {
     label {
-      top: .875rem;
+      transform: scale(1.2);
+      top: 1rem;
+      left: 16px;
     }
   }
 
   &:hover,
   &.focus {
-    input {
-      background-color: var(--color-dark);
-      border-radius: var(--border-radius);
-    }
+    border: 1px solid var(--color-primary);
 
     .input-prepend {
       background-color: var(--color-primary);
     }
 
     label {
+      transform: scale(1);
       top: .1875rem;
+      left: 12px;
     }
   }
   

--- a/src/components/atoms/Input/helpers/TextInput.tsx
+++ b/src/components/atoms/Input/helpers/TextInput.tsx
@@ -14,6 +14,7 @@ export interface TextInputProps {
   autoFocus?: boolean
   color?: string
   className?: string
+  disabled?: boolean
   errorMessage?: string
   errors?: NestDataObject<Record<string, string>, FieldError>
   getValues?: any // eslint-disable-line
@@ -41,6 +42,7 @@ export const TextInput: TextInput = ({
   autoFocus = false,
   children,
   className,
+  disabled = false,
   errorMessage,
   errors = {},
   icon,
@@ -135,6 +137,7 @@ export const TextInput: TextInput = ({
         <input
           autoFocus={isFocus}
           autoComplete={autoComplete}
+          disabled={disabled}
           name={name}
           type={type === 'password' ? passwordShown ? 'text' : 'password' : type}
           id={name}
@@ -183,10 +186,7 @@ const StyledInput = styled.div<StyledInputProps>`
   font-size: 1em;
   border-radius: var(--radius);
   transition: all 200ms ease-in-out;
-
-  &.error {
-    margin-bottom: var(--space-lgr);
-  }
+  outline: none;
 
   .show-password {
     display: flex;
@@ -260,6 +260,20 @@ const StyledInput = styled.div<StyledInputProps>`
     color: var(--color-white);
     outline: none;
     transition: top 200ms ease-in-out;
+
+    &:disabled {
+      cursor: not-allowed;
+    }
+  }
+
+  .error {
+    position: absolute;
+    right: 0px;
+    bottom: -24px;
+    padding: 2px 4px;
+    text-align: right;
+    color: var(--color-error);
+    font-size: var(--text-md);
   }
 
   &.empty {
@@ -270,10 +284,10 @@ const StyledInput = styled.div<StyledInputProps>`
     }
   }
 
+  
+
   &:hover,
   &.focus {
-    border: 1px solid var(--color-primary);
-
     .input-prepend {
       background-color: var(--color-primary);
     }
@@ -284,16 +298,19 @@ const StyledInput = styled.div<StyledInputProps>`
       left: 12px;
     }
   }
-  
-  .error {
-    position: absolute;
-    right: 0px;
-    bottom: -22px;
-    padding: 2px 4px;
-    text-align: right;
-    color: rgb(234,29,37);
-    font-size: var(--text-md);
-    border-radius: 3px;
+
+  &:hover {
+    border: 1px solid var(--color-white-30);
+    .input-prepend {
+      background-color: var(--color-white-20);
+    }
+  }
+
+  &:focus-within {
+    border: 1px solid var(--color-primary) !important;
+    .input-prepend {
+      background-color: var(--color-primary) !important;
+    }
   }
 `
 

--- a/src/components/atoms/Input/stories/input.stories.tsx
+++ b/src/components/atoms/Input/stories/input.stories.tsx
@@ -74,75 +74,103 @@ export default {
 }
 
 export const Basic = (args: InputProps) => (
-  <Wrapper>
-    <Input {...args} />
+  <Wrapper bgColor='black-darker'>
+    <Input {...args} style={{marginBottom: 0}}/>
   </Wrapper>
 )
 
 export const Text = () => (
-  <Wrapper>
+  <Wrapper bgColor='black-darker'>
     <Input
+      style={{marginBottom: 0}}
       name='Text'
       type='text'
       icon='shop'
       label='Text'
-      value='Default Value'
+      autoComplete='off'
+      autoFocus={true}
     />
   </Wrapper>
 )
 
-export const Color = () => (
-  <Wrapper>
+export const Date = () => (
+  <Wrapper bgColor='black-darker'>
     <Input
+      style={{marginBottom: 0}}
+      name='color'
+      type='date'
+      label='Pick a date'
+      autoComplete='off'
+      autoFocus={true}
+    />
+  </Wrapper>
+)
+export const Color = () => (
+  <Wrapper bgColor='black-darker'>
+    <Input
+      style={{marginBottom: 0}}
       name='color'
       type='color'
       label='Pick a color'
-      value='#123456'
+      autoComplete='off'
+      autoFocus={true}
     />
   </Wrapper>
 )
 
 export const CustomRegexPattern = () => (
-  <Wrapper>
+  <Wrapper bgColor='black-darker'>
     <Input
+      style={{marginBottom: 0}}
       name='CustomRegex'
       type='text'
       icon='shop'
       label='I match 4 digits numbers'
       pattern={/^[0-9]{4}$/}
+      autoComplete='off'
+      autoFocus={true}
     />
   </Wrapper>
 )
 
 export const Email = () => (
-  <Wrapper>
+  <Wrapper bgColor='black-darker'>
     <Input
+      style={{marginBottom: 0}}
       name='Email'
       type='email'
       icon='send'
       label='Email'
+      autoComplete='off'
+      autoFocus={true}
     />
   </Wrapper>
 )
 
 export const Number = () => (
-  <Wrapper>
+  <Wrapper bgColor='black-darker'>
     <Input
+      style={{marginBottom: 0}}
       name='number'
       type="number"
       icon='euro'
-      label="Number"
+      label='Number'
+      autoComplete='off'
+      autoFocus={true}
     />
   </Wrapper>
 )
 
 export const Password = () => (
-  <Wrapper>
+  <Wrapper bgColor='black-darker'>
     <Input
+      style={{marginBottom: 0}}
       name='password'
       label='Password'
       type='password'
       icon='lock'
+      autoComplete='off'
+      autoFocus={true}
     />
   </Wrapper>
 

--- a/src/components/atoms/PageHeader/PageHeader.tsx
+++ b/src/components/atoms/PageHeader/PageHeader.tsx
@@ -23,9 +23,14 @@ const StyledPageHeader = styled.header`
   background-color: var(--color-black-darker);
   padding: 20px 30px;
   border-radius: var(--radius);
+  height: 80px;
 
   h1 {
     margin-bottom: 0;
     font-size: var(--text-xl);
+  }
+
+  .page-header-toolbar {
+    display: flex;
   }
 `

--- a/src/components/atoms/PageHeader/PageHeader.tsx
+++ b/src/components/atoms/PageHeader/PageHeader.tsx
@@ -4,13 +4,14 @@ import styled from 'styled-components'
 // I N T E R F A C E S
 export interface PageHeaderProps {
   className?: string
+  style?: React.CSSProperties
 }
 
 // C O M P O N E N T
 export const PageHeader: React.FC<PageHeaderProps> = (props) => {
-  const { className, children } = props
+  const { className, children, style } = props
 
-  return <StyledPageHeader className={className}>{children}</StyledPageHeader>
+  return <StyledPageHeader className={className} style={style}>{children}</StyledPageHeader>
 }
 
 // S T Y L E S
@@ -19,8 +20,8 @@ const StyledPageHeader = styled.header`
   justify-content: space-between;
   align-items: center;
   margin-bottom: 20px;
-  background-color: var(--color-dark-50);
-  padding: 20px;
+  background-color: var(--color-black-darker);
+  padding: 20px 30px;
   border-radius: var(--radius);
 
   h1 {

--- a/src/components/atoms/Select/Select.tsx
+++ b/src/components/atoms/Select/Select.tsx
@@ -299,7 +299,8 @@ const StyledSelect = styled.div`
       left: 0;
       z-index: 2;
       overflow: hidden;
-      background-color: var(--color-dark);
+      border: var(--border);
+      background-color: var(--color-black);
       width: 100%;
       color: var(--color-white);
       appearance: none;
@@ -329,7 +330,7 @@ const StyledSelect = styled.div`
   select {
     position: relative;
     border: var(--border);
-    background-color: var(--color-dark);
+    background-color: var(--color-black);
     padding: 14px 0 0 calc(var(--icon-wrapper-size) + 12px);
     color: var(--color-white);
     appearance: none;

--- a/src/components/atoms/Tooltip/Tooltip.tsx
+++ b/src/components/atoms/Tooltip/Tooltip.tsx
@@ -38,7 +38,7 @@ const StyledTooltip = styled.div`
   color: var(--color-white);
 
   .tooltip-inner, &:before, &:after {
-    background-color: var(--color-black);
+    background-color: black;
   }
 
   .tooltip-inner {

--- a/src/components/introduction/layout/Section/Section.tsx
+++ b/src/components/introduction/layout/Section/Section.tsx
@@ -12,7 +12,7 @@ export interface SectionProps {
   style?: React.CSSProperties
 }
 
-export type BgColorType = 'black' | 'dark' | 'primary' | 'light' | 'white' | 'transparent'
+export type BgColorType = 'black' | 'dark' | 'primary' | 'light' | 'white' | 'transparent' | 'black-darker'
 
 // C O M P O N E N T
 export const Section: React.FC<SectionProps> = ({
@@ -61,6 +61,9 @@ const StyledSection = styled.div`
       color: var(--color-black);
     }
     background-color: var(--color-white);
+  }
+  &.section--black-darker {
+    background-color: var(--color-black-darker);
   }
   &.section--transparent {
     background-color: transparent;

--- a/src/components/organisms/Form/Form.tsx
+++ b/src/components/organisms/Form/Form.tsx
@@ -47,7 +47,7 @@ export const Form: React.FC<FormProps> = ({
 
 const StyledForm = styled.form`
   width: 100%;
-  
+
   .form-footer {
     display: flex;
     justify-content: space-between;
@@ -62,5 +62,9 @@ const StyledForm = styled.form`
         margin-right: 0;
       }
     }
+  }
+
+  .row {
+    margin-bottom: 0;
   }
 `

--- a/src/components/organisms/Form/form.stories.tsx
+++ b/src/components/organisms/Form/form.stories.tsx
@@ -3,6 +3,7 @@ import React from 'react'
 import { Form } from './Form'
 import { Input } from '../../atoms/Input/Input'
 import { Button } from '../../atoms/Button/Button'
+import { ButtonGroup } from '../../atoms/Button/ButtonGroup'
 import { Select } from '../../atoms/Select/Select'
 import Wrapper from '../../_helpers/Wrapper'
 
@@ -20,7 +21,7 @@ export default {
 }
 
 export const Basic = () => (
-  <Wrapper>
+  <Wrapper bgColor='black-darker'>
     <Form onSubmit={(data: Record<string, string> | undefined, setValue: any): void => { // eslint-disable-line
       if (data) {
         console.log(data)
@@ -35,7 +36,10 @@ export const Basic = () => (
       <Input type='color' name='lightColor' label='Light Color' value='#999999' />
       <Input type='date' name='date' label='Enter a date' />
       <Select name='select' label='Select your option' values={['option1', 'option2', 'option3']} icon='bestseller' />
-      <Button type='submit'>Submit</Button>
+      <ButtonGroup>
+        <Button type='black' width='block'>Cancel</Button>
+        <Button type='submit' width='block'>Submit</Button>
+      </ButtonGroup>
     </Form>
   </Wrapper>
 )

--- a/src/components/pages/adminland/Create/create.stories.tsx
+++ b/src/components/pages/adminland/Create/create.stories.tsx
@@ -1,0 +1,127 @@
+import React from 'react'
+import { MemoryRouter } from 'react-router-dom'
+
+import { Adminland } from '../../../templates/layouts/Adminland/Adminland'
+import { AdminNavigation } from '../../../templates/AdminNavigation/AdminNavigation'
+import { Container } from '../../../introduction/layout/Container/Container'
+import { Section } from '../../../introduction/layout/Section/Section'
+import { Row } from '../../../introduction/layout/Row/Row'
+import { Col } from '../../../introduction/layout/Col/Col'
+import { Page } from '../../../introduction/layout/Page/Page'
+import { Button } from '../../../atoms/Button/Button'
+import { ButtonGroup } from '../../../atoms/Button/ButtonGroup'
+import { Logo } from '../../../atoms/Logo/Logo'
+import { Input } from '../../../atoms/Input/Input'
+import { Tooltip } from '../../../atoms/Tooltip/Tooltip'
+import { Menu } from '../../../molecules/Menu/Menu'
+import { UserNav } from '../../../organisms/UserNav/UserNav'
+import { Form } from '../../../organisms/Form/Form'
+import { PageHeader } from '../../../atoms/PageHeader/PageHeader'
+
+export default {
+  title: '📙 Pages/Adminland/Create',
+}
+
+export const Basic = () => (
+  <MemoryRouter>
+    <Adminland>
+      <AdminNavigation>
+        <Logo
+          src='https://raw.githubusercontent.com/anynines-johannchopin/happy-static/master/a9s/assets/logos/light_vertical.svg?sanitize=true'
+          vertical
+        />
+        <Menu
+          selectedItem='/users'
+          items={[
+            {
+              children: <>Users</>,
+              icon: 'users',
+              id: '/users'
+            },
+            {
+              children: <>Pages</>,
+              icon: 'pages',
+              id: '/pages'
+            }
+          ]}
+          vertical
+        />
+        <UserNav
+          avatar='https://www.anynines.com/assets/team/profiles/2x/fischer-dd47fbfc116c0069ffd414d3784f5895044aaef3e2411414c5f0fc637624f030.jpg'
+          name='Julian Fischer'
+          description='CEO'
+          mode='dark'
+          setMode={() => {}}
+          logoutUser={() => {}}
+        />
+      </AdminNavigation>
+      <Page>
+        <Container containerSize='sm'>
+          <PageHeader>
+            <h1>Create something</h1>
+            <Button
+              iconOnly
+              type='black'
+              icon='bin'
+              className='tooltip-wrapper'
+            >
+              <Tooltip>Delete Something</Tooltip>
+            </Button>
+          </PageHeader>
+          <Section bgColor='black-darker'>
+            <Form onSubmit={(data: Record<string, string> | undefined, setValue: any): void => { // eslint-disable-line
+              if (data) {
+                console.log(data)
+                setValue('firstName', '')
+                setValue('lastName', '')
+                setValue('address', '')
+                setValue('address', '')
+              }
+            }}>
+              <Row style={{flexWrap: 'nowrap'}}>
+                <Col>
+                  <Input
+                    name='firstName'
+                    type='text'
+                    icon='user'
+                    label='First Name'
+                    value='John'
+                    autoFocus={true}
+                  />
+                  
+                </Col>
+                <Col>
+                  <Input
+                    name='lastName'
+                    type='text'
+                    icon='user'
+                    label='Last Name'
+                    value='Doe'
+                  />
+                </Col>
+              </Row>
+              <Input
+                name='email'
+                type='email'
+                icon='send'
+                label='Email'
+                value='johndoe@gmail.com'
+              />
+              <Input
+                name='address'
+                type='text'
+                icon='home'
+                label='Address'
+                value='Rosenstraße 42, 66111 Saarbrücken'
+              />
+              <ButtonGroup>
+                <Button type='black' width='block'>Cancel</Button>
+                <Button type='submit' width='block'>Submit</Button>
+              </ButtonGroup>
+            </Form>
+          </Section>
+        </Container>
+      </Page>
+    </Adminland>
+  </MemoryRouter>
+)

--- a/src/components/pages/adminland/create.stories.tsx
+++ b/src/components/pages/adminland/create.stories.tsx
@@ -1,0 +1,82 @@
+import React from 'react'
+import { MemoryRouter } from 'react-router-dom'
+
+import { Adminland } from '../../templates/layouts/Adminland/Adminland'
+import { AdminNavigationExample } from '../../templates/AdminNavigation/examples/AdminNavigationExample'
+import { Container } from '../../introduction/layout/Container/Container'
+import { Section } from '../../introduction/layout/Section/Section'
+import { Row } from '../../introduction/layout/Row/Row'
+import { Col } from '../../introduction/layout/Col/Col'
+import { Page } from '../../introduction/layout/Page/Page'
+import { Button } from '../../atoms/Button/Button'
+import { ButtonGroup } from '../../atoms/Button/ButtonGroup'
+import { Input } from '../../atoms/Input/Input'
+import { Form } from '../../organisms/Form/Form'
+import { PageHeader } from '../../atoms/PageHeader/PageHeader'
+
+export default {
+  title: '📙 Pages/Adminland',
+}
+
+export const Create = () => (
+  <MemoryRouter>
+    <Adminland>
+      <AdminNavigationExample />
+      <Page>
+        <Container containerSize='sm'>
+          <PageHeader>
+            <h1>Create something</h1>
+          </PageHeader>
+          <Section bgColor='black-darker'>
+            <Form onSubmit={(data: Record<string, string> | undefined, setValue: any): void => { // eslint-disable-line
+              if (data) {
+                console.log(data)
+                setValue('firstName', '')
+                setValue('lastName', '')
+                setValue('address', '')
+                setValue('address', '')
+              }
+            }}>
+              <Row style={{flexWrap: 'nowrap'}}>
+                <Col>
+                  <Input
+                    name='firstName'
+                    type='text'
+                    icon='user'
+                    label='First Name'
+                    autoFocus={true}
+                  />
+                  
+                </Col>
+                <Col>
+                  <Input
+                    name='lastName'
+                    type='text'
+                    icon='user'
+                    label='Last Name'
+                  />
+                </Col>
+              </Row>
+              <Input
+                name='email'
+                type='email'
+                icon='send'
+                label='Email'
+              />
+              <Input
+                name='address'
+                type='text'
+                icon='home'
+                label='Address'
+              />
+              <ButtonGroup>
+                <Button type='black' width='block'>Cancel</Button>
+                <Button type='submit' width='block'>Create Something</Button>
+              </ButtonGroup>
+            </Form>
+          </Section>
+        </Container>
+      </Page>
+    </Adminland>
+  </MemoryRouter>
+)

--- a/src/components/pages/adminland/edit.stories.tsx
+++ b/src/components/pages/adminland/edit.stories.tsx
@@ -1,64 +1,32 @@
 import React from 'react'
 import { MemoryRouter } from 'react-router-dom'
 
-import { Adminland } from '../../../templates/layouts/Adminland/Adminland'
-import { AdminNavigation } from '../../../templates/AdminNavigation/AdminNavigation'
-import { Container } from '../../../introduction/layout/Container/Container'
-import { Section } from '../../../introduction/layout/Section/Section'
-import { Row } from '../../../introduction/layout/Row/Row'
-import { Col } from '../../../introduction/layout/Col/Col'
-import { Page } from '../../../introduction/layout/Page/Page'
-import { Button } from '../../../atoms/Button/Button'
-import { ButtonGroup } from '../../../atoms/Button/ButtonGroup'
-import { Logo } from '../../../atoms/Logo/Logo'
-import { Input } from '../../../atoms/Input/Input'
-import { Tooltip } from '../../../atoms/Tooltip/Tooltip'
-import { Menu } from '../../../molecules/Menu/Menu'
-import { UserNav } from '../../../organisms/UserNav/UserNav'
-import { Form } from '../../../organisms/Form/Form'
-import { PageHeader } from '../../../atoms/PageHeader/PageHeader'
+import { Adminland } from '../../templates/layouts/Adminland/Adminland'
+import { AdminNavigationExample } from '../../templates/AdminNavigation/examples/AdminNavigationExample'
+import { Container } from '../../introduction/layout/Container/Container'
+import { Section } from '../../introduction/layout/Section/Section'
+import { Row } from '../../introduction/layout/Row/Row'
+import { Col } from '../../introduction/layout/Col/Col'
+import { Page } from '../../introduction/layout/Page/Page'
+import { Button } from '../../atoms/Button/Button'
+import { ButtonGroup } from '../../atoms/Button/ButtonGroup'
+import { Input } from '../../atoms/Input/Input'
+import { Tooltip } from '../../atoms/Tooltip/Tooltip'
+import { Form } from '../../organisms/Form/Form'
+import { PageHeader } from '../../atoms/PageHeader/PageHeader'
 
 export default {
-  title: '📙 Pages/Adminland/Create',
+  title: '📙 Pages/Adminland',
 }
 
-export const Basic = () => (
+export const Edit = () => (
   <MemoryRouter>
     <Adminland>
-      <AdminNavigation>
-        <Logo
-          src='https://raw.githubusercontent.com/anynines-johannchopin/happy-static/master/a9s/assets/logos/light_vertical.svg?sanitize=true'
-          vertical
-        />
-        <Menu
-          selectedItem='/users'
-          items={[
-            {
-              children: <>Users</>,
-              icon: 'users',
-              id: '/users'
-            },
-            {
-              children: <>Pages</>,
-              icon: 'pages',
-              id: '/pages'
-            }
-          ]}
-          vertical
-        />
-        <UserNav
-          avatar='https://www.anynines.com/assets/team/profiles/2x/fischer-dd47fbfc116c0069ffd414d3784f5895044aaef3e2411414c5f0fc637624f030.jpg'
-          name='Julian Fischer'
-          description='CEO'
-          mode='dark'
-          setMode={() => {}}
-          logoutUser={() => {}}
-        />
-      </AdminNavigation>
+      <AdminNavigationExample />
       <Page>
         <Container containerSize='sm'>
           <PageHeader>
-            <h1>Create something</h1>
+            <h1>Edit something</h1>
             <Button
               iconOnly
               type='black'
@@ -116,7 +84,7 @@ export const Basic = () => (
               />
               <ButtonGroup>
                 <Button type='black' width='block'>Cancel</Button>
-                <Button type='submit' width='block'>Submit</Button>
+                <Button type='submit' width='block'>Edit Something</Button>
               </ButtonGroup>
             </Form>
           </Section>

--- a/src/components/pages/adminland/index.stories.tsx
+++ b/src/components/pages/adminland/index.stories.tsx
@@ -1,0 +1,52 @@
+import React from 'react'
+import { MemoryRouter } from 'react-router-dom'
+
+import { Adminland } from '../../templates/layouts/Adminland/Adminland'
+import { AdminNavigationExample } from '../../templates/AdminNavigation/examples/AdminNavigationExample'
+import { Container } from '../../introduction/layout/Container/Container'
+import { Section } from '../../introduction/layout/Section/Section'
+import { Page } from '../../introduction/layout/Page/Page'
+import { Button } from '../../atoms/Button/Button'
+import { Tooltip } from '../../atoms/Tooltip/Tooltip'
+import { PageHeader } from '../../atoms/PageHeader/PageHeader'
+
+export default {
+  title: '📙 Pages/Adminland',
+}
+
+export const Index = () => (
+  <MemoryRouter>
+    <Adminland>
+      <AdminNavigationExample />
+      <Page>
+        <Container containerSize='sm'>
+          <PageHeader>
+            <h1>Somethings</h1>
+            <div className='page-header-toolbar'>
+              <Button
+                iconOnly
+                type='black'
+                icon='grid4'
+                className='tooltip-wrapper'
+              >
+                <Tooltip>This could do something</Tooltip>
+              </Button>
+              <Button
+                iconOnly
+                style={{ marginLeft: 20 }}
+                type='black'
+                icon='grid1'
+                className='tooltip-wrapper'
+              >
+                <Tooltip>Something else</Tooltip>
+              </Button>
+            </div>
+          </PageHeader>
+          <Section bgColor='black-darker'>
+            <span>Table will soon come here</span>
+          </Section>
+        </Container>
+      </Page>
+    </Adminland>
+  </MemoryRouter>
+)

--- a/src/components/pages/adminland/read.stories.tsx
+++ b/src/components/pages/adminland/read.stories.tsx
@@ -1,0 +1,98 @@
+import React from 'react'
+import { MemoryRouter } from 'react-router-dom'
+
+import { Adminland } from '../../templates/layouts/Adminland/Adminland'
+import { AdminNavigationExample } from '../../templates/AdminNavigation/examples/AdminNavigationExample'
+import { Container } from '../../introduction/layout/Container/Container'
+import { Section } from '../../introduction/layout/Section/Section'
+import { Row } from '../../introduction/layout/Row/Row'
+import { Col } from '../../introduction/layout/Col/Col'
+import { Page } from '../../introduction/layout/Page/Page'
+import { Button } from '../../atoms/Button/Button'
+import { Input } from '../../atoms/Input/Input'
+import { Tooltip } from '../../atoms/Tooltip/Tooltip'
+import { Form } from '../../organisms/Form/Form'
+import { PageHeader } from '../../atoms/PageHeader/PageHeader'
+
+export default {
+  title: '📙 Pages/Adminland',
+}
+
+export const Read = () => (
+  <MemoryRouter>
+    <Adminland>
+      <AdminNavigationExample />
+      <Page>
+        <Container containerSize='sm'>
+          <PageHeader>
+            <h1>John Doe</h1>
+            <div className='page-header-toolbar'>
+              <Button
+                iconOnly
+                type='black'
+                icon='edit'
+                className='tooltip-wrapper'
+              >
+                <Tooltip>Edit John Doe</Tooltip>
+              </Button>
+              <Button
+                iconOnly
+                style={{ marginLeft: 20 }}
+                type='black'
+                icon='bin'
+                className='tooltip-wrapper'
+              >
+                <Tooltip>Delete John Doe</Tooltip>
+              </Button>
+              
+            </div>
+          </PageHeader>
+          <Section bgColor='black-darker'>
+            <Form>
+              <Row style={{flexWrap: 'nowrap'}}>
+                <Col>
+                  <Input
+                    disabled={true}
+                    icon='user'
+                    label='First Name'
+                    name='firstName'
+                    type='text'
+                    value='John'
+                  />
+                  
+                </Col>
+                <Col>
+                  <Input
+                    disabled={true}
+                    icon='user'
+                    label='Last Name'
+                    name='lastName'
+                    type='text'
+                    value='Doe'
+                  />
+                </Col>
+              </Row>
+              <Input
+                disabled={true}
+                icon='send'
+                label='Email'
+                name='email'
+                type='email'
+                value='johndoe@gmail.com'
+              />
+              <Input
+                disabled={true}
+                icon='home'
+                label='Address'
+                name='address'
+                type='text'
+                style={{ marginBottom: 0 }}
+                value='Rosenstraße 42, 66111 Saarbrücken'
+              />
+            </Form>
+          </Section>
+        </Container>
+      </Page>
+    </Adminland>
+  </MemoryRouter>
+)

--- a/src/components/templates/AdminNavigation/AdminNavigation.tsx
+++ b/src/components/templates/AdminNavigation/AdminNavigation.tsx
@@ -1,43 +1,14 @@
 import React from 'react'
 import styled from 'styled-components'
 
-import { IconName } from '../../atoms/Icon/Icon'
-import { Logo } from '../../atoms/Logo/Logo'
-import { Menu } from '../../molecules/Menu/Menu'
-import { UserNav, UserNavProps } from '../../organisms/UserNav/UserNav'
-import { Mode } from '../../../designSystemInstance/types/types'
-
 export interface AdminNavigationProps {
-  activeLink: string
   className?: string
-  links?: AdminNavigationLink[]
-  logoSrc: string
-  logoutUser: () => void
-  mode: Mode
-  onLinkClick: (link: string) => void
-  setMode: (mode: Mode) => void
   style?: React.CSSProperties
-  userInfo: Omit<UserNavProps, 'mode' | 'setMode' | 'logoutUser' | 'className'>
-}
-
-export interface AdminNavigationLink {
-  children: JSX.Element
-  icon?: IconName
-  id: string
-  path?: string
 }
 
 export const AdminNavigation: React.FC<AdminNavigationProps> = ({
-  activeLink,
   className,
-  links,
-  logoSrc,
-  logoutUser,
-  mode,
-  onLinkClick,
-  setMode,
   style,
-  userInfo,
   children
 }) => {
   return (
@@ -45,28 +16,7 @@ export const AdminNavigation: React.FC<AdminNavigationProps> = ({
       style={style}
       className={`admin-navigation ${className}`}
     >
-      <Logo
-        src={logoSrc}
-        vertical
-      />
-
       {children}
-
-      <Menu
-        items={links}
-        onClick={onLinkClick}
-        selectedItem={activeLink}
-        vertical
-      />
-
-      <UserNav
-        avatar={userInfo.avatar}
-        name={userInfo.name}
-        description={userInfo.description}
-        mode={mode}
-        setMode={setMode}
-        logoutUser={logoutUser}
-      />
     </StyledAdminNavigation>
   )
 }
@@ -79,10 +29,10 @@ const StyledAdminNavigation = styled.div`
   top: 20px;
   left: 20px;
   overflow: hidden;
-  background-color: var(--color-dark);
+  background-color: var(--color-black-darker);
   padding: var(--space-lg);
   padding-top: 30px;
-  width: 280px;
+  width: 260px;
   height: calc(100vh - 40px);
   color: var(--color-white);
   border-radius: var(--radius);
@@ -96,7 +46,8 @@ const StyledAdminNavigation = styled.div`
   .user-nav {
     position: absolute;
     bottom: 0;
-    background-color: var(--color-black-50);
+    border-top: var(--border);
+    background-color: transparent;
   }
 
   .logo-wrapper {

--- a/src/components/templates/AdminNavigation/examples/AdminNavigationExample.tsx
+++ b/src/components/templates/AdminNavigation/examples/AdminNavigationExample.tsx
@@ -1,0 +1,45 @@
+import React from 'react'
+
+import { AdminNavigation } from '../AdminNavigation'
+import { Logo } from '../../../atoms/Logo/Logo'
+import { Menu } from '../../../molecules/Menu/Menu'
+import { UserNav } from '../../../organisms/UserNav/UserNav'
+
+export const AdminNavigationExample: React.FC = () => {
+  const brandLogo = 'https://raw.githubusercontent.com/anynines-johannchopin/happy-static/master/a9s/assets/logos/light_vertical.svg?sanitize=true'
+
+  const userAvatar = 'https://www.anynines.com/assets/team/profiles/2x/fischer-dd47fbfc116c0069ffd414d3784f5895044aaef3e2411414c5f0fc637624f030.jpg'
+
+  return (
+    <AdminNavigation>
+      <Logo
+        src={brandLogo}
+        vertical
+      />
+      <Menu
+        selectedItem='/users'
+        items={[
+          {
+            children: <>Users</>,
+            icon: 'users',
+            id: '/users'
+          },
+          {
+            children: <>Pages</>,
+            icon: 'pages',
+            id: '/pages'
+          }
+        ]}
+        vertical
+      />
+      <UserNav
+        avatar={userAvatar}
+        name='Julian Fischer'
+        description='CEO'
+        mode='dark'
+        setMode={(): void => { console.log('setMode') }}
+        logoutUser={(): void => { console.log('logoutUser') }}
+      />
+    </AdminNavigation>
+  )
+}

--- a/src/components/templates/AdminNavigation/stories/adminNavigation.stories.tsx
+++ b/src/components/templates/AdminNavigation/stories/adminNavigation.stories.tsx
@@ -2,7 +2,9 @@ import React from 'react'
 import { BrowserRouter as Router } from 'react-router-dom'
 
 import { AdminNavigation, AdminNavigationProps } from '../AdminNavigation'
-
+import { Logo } from '../../../atoms/Logo/Logo'
+import { Menu } from '../../../molecules/Menu/Menu'
+import { UserNav } from '../../../organisms/UserNav/UserNav'
 
 export default {
   title: '📄 Templates/AdminNavigation',
@@ -11,36 +13,35 @@ export default {
 
 export const Basic = (args: AdminNavigationProps) => (
   <Router>
-    <AdminNavigation
-      logoSrc='https://raw.githubusercontent.com/anynines-johannchopin/happy-static/master/a9s/assets/logos/light_vertical.svg?sanitize=true'
-      links={[
-        {
-          id: '/users',
-          icon: 'users',
-          children: <>Users</>
-        },
-        {
-          id: '/pages',
-          icon: 'pages',
-          children: <>Pages</>
-        }
-      ]}
-      onLinkClick={(clickedLink) => {
-        console.log(clickedLink)
-      }}
-      activeLink='/pages'
-      setMode={(mode): void => { console.log(`Mode set to: ${mode}`) }}
-      mode='dark'
-      logoutUser={(): void => { console.log('logout user') }}
-      userInfo={{
-        avatar: 'https://www.anynines.com/assets/team/profiles/2x/fischer-dd47fbfc116c0069ffd414d3784f5895044aaef3e2411414c5f0fc637624f030.jpg',
-        name: 'Morgan Kelin',
-        description: 'CEO'
-      }}
-      style={{
-        width: 260,
-        height: '100vh'
-      }}
-    />
+    <AdminNavigation>
+      <Logo
+        src='https://raw.githubusercontent.com/anynines-johannchopin/happy-static/master/a9s/assets/logos/light_vertical.svg?sanitize=true'
+        vertical
+      />
+      <Menu
+        selectedItem='/users'
+        items={[
+          {
+            children: <>Users</>,
+            icon: 'users',
+            id: '/users'
+          },
+          {
+            children: <>Pages</>,
+            icon: 'pages',
+            id: '/pages'
+          }
+        ]}
+        vertical
+      />
+      <UserNav
+        avatar='https://www.anynines.com/assets/team/profiles/2x/fischer-dd47fbfc116c0069ffd414d3784f5895044aaef3e2411414c5f0fc637624f030.jpg'
+        name='Julian Fischer'
+        description='CEO'
+        mode='dark'
+        setMode={() => {}}
+        logoutUser={() => {}}
+      />
+    </AdminNavigation>
   </Router>
 )

--- a/src/components/templates/TopNavigation/TopNavigation.tsx
+++ b/src/components/templates/TopNavigation/TopNavigation.tsx
@@ -30,7 +30,7 @@ const StyledTopNavigation = styled.div`
   left: 0;
   z-index: 100;
   border-bottom: 1px solid var(--color-white-10);
-  background: var(--color-darker);
+  background: var(--color-black-darker);
   padding: 20px;
   width: 100%;
   height: 80px;

--- a/src/components/templates/layouts/Adminland/Adminland.tsx
+++ b/src/components/templates/layouts/Adminland/Adminland.tsx
@@ -23,13 +23,20 @@ export const Adminland: React.FC<AdminlandProps> = ({
 
 const StyledAdminland = styled.div`
   padding: 20px;
-  padding-left: 320px;
+  padding-left: 300px;
   
   .page {
     margin-top: 0;
   }
 
   .section {
+    margin-bottom: 20px;
+    background-color: var(--color-black-darker);
+    padding: 30px;
     border-radius: var(--radius);
+
+    &:last-child {
+      margin-bottom: 0;
+    }
   }
 `

--- a/src/components/templates/layouts/Adminland/stories/adminland.stories.tsx
+++ b/src/components/templates/layouts/Adminland/stories/adminland.stories.tsx
@@ -3,8 +3,14 @@ import { MemoryRouter } from 'react-router-dom'
 
 import { Adminland } from '../Adminland'
 import { AdminNavigation } from '../../../AdminNavigation/AdminNavigation'
+import { Container } from '../../../../introduction/layout/Container/Container'
 import { Section } from '../../../../introduction/layout/Section/Section'
 import { Page } from '../../../../introduction/layout/Page/Page'
+import { Logo } from '../../../../atoms/Logo/Logo'
+import { Button } from '../../../../atoms/Button/Button'
+import { Menu } from '../../../../molecules/Menu/Menu'
+import { UserNav } from '../../../../organisms/UserNav/UserNav'
+import { PageHeader } from '../../../../atoms/PageHeader/PageHeader'
 
 export default {
   title: '📄 Templates/Layouts/Adminland',
@@ -14,37 +20,50 @@ export default {
 export const Basic = () => (
   <MemoryRouter>
     <Adminland>
-      <AdminNavigation
-        activeLink="/pages"
-        links={[
-          {
-            children: <>Users</>,
-            icon: 'users',
-            id: '/users'
-          },
-          {
-            children: <>Pages</>,
-            icon: 'pages',
-            id: '/pages'
-          }
-        ]}
-        logoSrc="https://raw.githubusercontent.com/anynines-johannchopin/happy-static/master/a9s/assets/logos/light_vertical.svg?sanitize=true"
-        logoutUser={() => {}}
-        mode="dark"
-        onLinkClick={function noRefCheck() {}}
-        setMode={function noRefCheck() {}}
-        style={{
-        }}
-        userInfo={{
-          avatar: 'https://www.anynines.com/assets/team/profiles/2x/fischer-dd47fbfc116c0069ffd414d3784f5895044aaef3e2411414c5f0fc637624f030.jpg',
-          description: 'CEO',
-          name: 'Morgan Kelin'
-        }}
-      />
+      <AdminNavigation>
+        <Logo
+          src='https://raw.githubusercontent.com/anynines-johannchopin/happy-static/master/a9s/assets/logos/light_vertical.svg?sanitize=true'
+          vertical
+        />
+        <Menu
+          items={[
+            {
+              children: <>Users</>,
+              icon: 'users',
+              id: '/users'
+            },
+            {
+              children: <>Pages</>,
+              icon: 'pages',
+              id: '/users'
+            }
+          ]}
+          vertical
+        />
+        <UserNav
+          avatar='https://www.anynines.com/assets/team/profiles/2x/fischer-dd47fbfc116c0069ffd414d3784f5895044aaef3e2411414c5f0fc637624f030.jpg'
+          name='Julian Fischer'
+          description='CEO'
+          mode='dark'
+          setMode={function noRefCheck() {}}
+          logoutUser={() => {}}
+        />
+      </AdminNavigation>
       <Page>
-        <Section>
-          <h2>Place here some content</h2>
-        </Section>
+        <Container>
+          <PageHeader>
+            <h1>Feature Name</h1>
+            <Button>
+              Do something
+            </Button>
+          </PageHeader>
+          <Section>
+            <span>Some Component</span>
+          </Section>
+          <Section>
+            <span>Some other Component</span>
+          </Section>
+        </Container>
       </Page>
     </Adminland>
   </MemoryRouter>

--- a/src/components/templates/layouts/AuthLayout/AuthLayout.tsx
+++ b/src/components/templates/layouts/AuthLayout/AuthLayout.tsx
@@ -41,7 +41,7 @@ const StyledAuthLayout = styled.div<StyledAuthLayoutProps>`
   display: flex;
   justify-content: center;
   align-items: center;
-  background-color: var(--color-dark);
+  background-color: var(--color-black);
   width: 100%;
   height: 100vh;
 
@@ -56,7 +56,7 @@ const StyledAuthLayout = styled.div<StyledAuthLayoutProps>`
     display: flex;
     align-items: stretch;
     overflow: hidden;
-    background-color: var(--color-black);
+    background-color: var(--color-black-darker);
     border-radius: var(--radius);
     box-shadow: var(--shadow);
     width: 900px;

--- a/src/designSystemInstance/theme/GlobalStyle.tsx
+++ b/src/designSystemInstance/theme/GlobalStyle.tsx
@@ -43,6 +43,7 @@ export const GlobalStyle = createGlobalStyle`
     ${(props): string => { return builder.buildContrastPaletteFromHexColor(props.theme.globals.colors.black, 'Black') }}
 
     --color-white-fix: ${(props): string => { return props.theme.globals.colors.whiteFix }};
+    --color-black-darker: #040B18;
     
     /* G L O B A L S */
     --radius: ${(props): string => { return props.theme.globals.radius }};
@@ -153,7 +154,7 @@ export const GlobalStyle = createGlobalStyle`
     font-weight: var(--font-weight-lt);
   }
 
-  button, span {
+  button, span, input, select, blockquote {
     font-family: var(--font-family);
   }
 
@@ -214,6 +215,13 @@ export const GlobalStyle = createGlobalStyle`
 
   * {
     box-sizing: border-box;
+  }
+
+  input:-webkit-autofill,
+  input:-webkit-autofill:hover, 
+  input:-webkit-autofill:focus {
+    box-shadow: 0 0 0 30px var(--color-dark) inset !important;
+    -webkit-text-fill-color: white;
   }
 
   .tooltip-wrapper {

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -15,6 +15,7 @@ export * from './components/introduction/layout/Section/Section'
 // A T O M S
 export * from './components/atoms/Avatar/Avatar'
 export * from './components/atoms/Button/Button'
+export * from './components/atoms/Button/ButtonGroup'
 export * from './components/atoms/Box/Box'
 export * from './components/atoms/CaretLink/CaretLink'
 export * from './components/atoms/Favicon/Favicon'


### PR DESCRIPTION
Ready for CR 👍 

@nkiefera9s Probably something like this would be helpful anyways, but more importantly this could lead to an automated changelog like we have now manually, right? 

- Adds `Pages / Adminland / Edit`
- Adds `Pages / Adminland / Read`
- Adds `Pages / Adminland / Index` _- did not yet implement the actual table - but setup everything properly._
- Adds `Templates / AdminNavigation / Example` - _this is a AdminNavigation with Mock data, used as a helper inside stories (to keep them short)_
- Changed `Atoms / Inputs` 
-- added **disabled** prop to  to have proper `read-only` experience. 
-- improved `:hover` and `:focus` styling
- Changed `Atoms / PageHeader
-- added styling for PageHeader toolbar _- a container to handle multiple buttons in the PageHeader component_ 